### PR TITLE
select all text in field when widget called

### DIFF
--- a/web/findWidget.ts
+++ b/web/findWidget.ts
@@ -121,6 +121,7 @@ class FindWidget {
 			this.widgetElem.classList.add(CLASS_ACTIVE);
 		}
 		this.inputElem.focus();
+		this.inputElem.select();
 	}
 
 	/**


### PR DESCRIPTION
Summary of the issue:
text in field are selected when widget opened like browser.
