### PR TITLE
Added double newline support

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -865,7 +865,21 @@ class GitGraphView {
 
 		for (let i = 0; i < this.commits.length; i++) {
 			let commit = this.commits[i];
-			let message = '<span class="text">' + textFormatter.format(commit.message) + '</span>';
+			let subject = commit.message;
+			let body = '';
+
+			let splitMessage = commit.message.split('\n\n');
+
+			if(splitMessage.length > 1) {
+				subject = splitMessage[0];
+				splitMessage.shift();
+				body = splitMessage.join('\n\n');
+			}
+
+			let message = '<span class="text">' + textFormatter.format(subject) + '</span>';
+			if(body !== '') {
+				message += '<span class="text commitbody">' + textFormatter.format(body) + '</span>';
+			}
 			let date = formatShortDate(commit.date);
 			let branchLabels = getBranchLabels(commit.heads, commit.remotes);
 			let refBranches = '', refTags = '', j, k, refName, remoteName, refActive, refHtml, branchCheckedOutAtCommit: string | null = null;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -227,7 +227,12 @@ code{
 	text-overflow:ellipsis;
 	white-space:nowrap;
 	overflow:hidden;
-	flex-grow:1;
+	/*	flex-grow:1; */
+	margin-right:1em;
+}
+
+#commitTable tr.commit span.description .text.commitbody{
+	opacity: 0.5;
 }
 
 #commitTable tr.commit.mute td.text, #commitTable tr.commit.mute span.description .text{


### PR DESCRIPTION
### Summary of the issue:

I was working on migrating away from [GitKraken](https://gitkraken.com) when i realized that this extension does not render commits that feature a double newline between their first and further lines in a neat way.

To my knowledge, this commit message format is commonly used to declare a `subject` and `description` for commits. [GitKraken](https://gitkraken.com) renders any `description` declared this way next to the `subject` at a lower opacity.

I wanted to add support for neatly displaying commits that are declared this way, since i heavily rely on getting a preview of my commit message's `description` in the log of my Git GUIs.

### Description outlining how this pull request resolves the issue:

I resolved this by changing the `dataSource.ts`'s `gitFormatLog` to use the entire body (`%B`) instead of just the subject (`%s`) of commits. I then adjusted the functions that make use of `gitFormatLog` to handle the output accordingly.

I also adjusted `main.ts` to detect whether or not a message contains a double newline (`\n\n`) after the first chunk of text. If any double newline is present, the rendering is adjusted accordingly. The CSS got some minor changes to support this as well.

### Notes
> [!Warning]
Let me know if this breaks anything on your end, or if this should become an optional setting instead of the default behaviour!