### PR TITLE
Add configurable font size and row height for commit table

### DIFF
--- a/package.json
+++ b/package.json
@@ -762,6 +762,20 @@
 					"default": "rounded",
 					"description": "Specifies the style of the graph."
 				},
+				"git-graph.graph.fontSize": {
+					"type": "integer",
+					"minimum": 8,
+					"maximum": 24,
+					"default": 13,
+					"description": "Specifies the font size (in pixels) of the text in the commit table."
+				},
+				"git-graph.graph.rowHeight": {
+					"type": "integer",
+					"minimum": 16,
+					"maximum": 48,
+					"default": 24,
+					"description": "Specifies the height (in pixels) of each row in the commit table."
+				},
 				"git-graph.graph.uncommittedChanges": {
 					"type": "string",
 					"enum": [

--- a/src/config.ts
+++ b/src/config.ts
@@ -276,7 +276,9 @@ class Config {
 			style: this.getRenamedExtensionSetting<string>('graph.style', 'graphStyle', 'rounded') === 'angular'
 				? GraphStyle.Angular
 				: GraphStyle.Rounded,
-			grid: { x: 16, y: 24, offsetX: 16, offsetY: 12, expandY: 250 },
+			fontSize: this.config.get<number>('graph.fontSize', 13),
+			rowHeight: this.config.get<number>('graph.rowHeight', 24),
+			grid: { x: 16, y: this.config.get<number>('graph.rowHeight', 24), offsetX: 16, offsetY: this.config.get<number>('graph.rowHeight', 24) / 2, expandY: 250 },
 			uncommittedChanges: this.config.get<string>('graph.uncommittedChanges', 'Open Circle at the Uncommitted Changes') === 'Open Circle at the Checked Out Commit'
 				? GraphUncommittedChangesStyle.OpenCircleAtTheCheckedOutCommit
 				: GraphUncommittedChangesStyle.OpenCircleAtTheUncommittedChanges

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,6 +288,8 @@ export interface CommitDetailsViewConfig {
 
 export interface GraphConfig {
 	readonly colours: ReadonlyArray<string>;
+	readonly fontSize: number;
+	readonly rowHeight: number;
 	readonly style: GraphStyle;
 	readonly grid: { x: number, y: number, offsetX: number, offsetY: number, expandY: number };
 	readonly uncommittedChanges: GraphUncommittedChangesStyle;

--- a/web/main.ts
+++ b/web/main.ts
@@ -9,7 +9,7 @@
 // The authenticity of host 'github.pie.apple.com (17.121.132.15)' can't be established.
 // ECDSA key fingerprint is SHA256:7ZIubzLSVVGGQ2BgrPF+QnkDYjuJ/xs754ZS8oAZ7QY.
 // This key is not known by any other names.
-// Are you sure you want to continue connecting (yes/no/[fingerprint])? 
+// Are you sure you want to continue connecting (yes/no/[fingerprint])?
 class GitGraphView {
 	private gitRepos: GG.GitRepoSet;
 	private gitBranches: ReadonlyArray<string> = [];
@@ -139,6 +139,8 @@ class GitGraphView {
 
 		alterClass(document.body, CLASS_BRANCH_LABELS_ALIGNED_TO_GRAPH, this.config.referenceLabels.branchLabelsAlignedToGraph);
 		alterClass(document.body, CLASS_TAG_LABELS_RIGHT_ALIGNED, this.config.referenceLabels.tagLabelsOnRight);
+		document.body.style.setProperty('--git-graph-fontSize', this.config.graph.fontSize + 'px');
+		document.body.style.setProperty('--git-graph-rowHeight', this.config.graph.rowHeight + 'px');
 
 		this.observeWindowSizeChanges();
 		this.observeWebviewStyleChanges();

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -193,13 +193,13 @@ code{
 }
 #commitTable th, #commitTable td{
 	white-space:nowrap;
-	font-size:13px;
+	font-size:var(--git-graph-fontSize, 13px);
 	cursor:default;
 	text-overflow:ellipsis;
 	overflow:hidden;
 }
 #commitTable td{
-	line-height:24px;
+	line-height:var(--git-graph-rowHeight, 24px);
 	padding:0 4px;
 }
 #commitTable th{


### PR DESCRIPTION
## Summary
- Adds two new settings under **Git-graph > Graph**:
  - `git-graph.graph.fontSize` — font size in pixels (default: 13, range: 8–24)
  - `git-graph.graph.rowHeight` — row height in pixels (default: 24, range: 16–48)
- The graph canvas grid is automatically derived from the row height setting, so the graph lines stay aligned with the table rows
- CSS uses custom properties with sensible fallbacks

## Test plan
- [x] Open settings, search "git graph font size" and "git graph row height" — both appear under Git-graph > Graph
- [x] Change row height (e.g. to 32) → reload Git Graph → rows are taller, graph lines align
- [x] Change font size (e.g. to 16) → reload Git Graph → text is larger
- [x] Default values (13px font, 24px row height) match the original appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)