### PR TITLE
Add Git notes support

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,10 @@
 						"commit": {
 							"type": "object",
 							"properties": {
+								"addNote": {
+									"type": "boolean",
+									"title": "Add Note..."
+								},
 								"addTag": {
 									"type": "boolean",
 									"title": "Add Tag..."
@@ -260,6 +264,27 @@
 								"copySubject": {
 									"type": "boolean",
 									"title": "Copy Commit Subject to Clipboard"
+								}
+							}
+						},
+						"note": {
+							"type": "object",
+							"properties": {
+								"view": {
+									"type": "boolean",
+									"title": "View Note"
+								},
+								"edit": {
+									"type": "boolean",
+									"title": "Edit Note..."
+								},
+								"delete": {
+									"type": "boolean",
+									"title": "Delete Note..."
+								},
+								"copy": {
+									"type": "boolean",
+									"title": "Copy Note to Clipboard"
 								}
 							}
 						},

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,8 +82,9 @@ class Config {
 		const userConfig = this.config.get('contextMenuActionsVisibility', {});
 		const config: ContextMenuActionsVisibility = {
 			branch: { checkout: true, rename: true, delete: true, merge: true, rebase: true, push: true, pull: true, createBranch: true, viewIssue: true, createPullRequest: true, createArchive: true, selectInBranchesDropdown: true, unselectInBranchesDropdown: true, copyName: true },
-			commit: { addTag: true, createBranch: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, undo: true, editMessage: true, copyHash: true, copySubject: true },
+			commit: { addNote: true, addTag: true, createBranch: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, undo: true, editMessage: true, copyHash: true, copySubject: true },
 			commitDetailsViewFile: { viewDiff: true, viewFileAtThisRevision: true, viewDiffWithWorkingFile: true, openFile: true, markAsReviewed: true, markAsNotReviewed: true, resetFileToThisRevision: true, copyAbsoluteFilePath: true, copyRelativeFilePath: true },
+			note: { view: true, edit: true, delete: true, copy: true },
 			remoteBranch: { checkout: true, delete: true, fetch: true, merge: true, pull: true, createBranch: true, viewIssue: true, createPullRequest: true, createArchive: true, selectInBranchesDropdown: true, unselectInBranchesDropdown: true, copyName: true },
 			stash: { apply: true, createBranch: true, pop: true, drop: true, copyName: true, copyHash: true },
 			tag: { viewDetails: true, delete: true, push: true, createArchive: true, copyName: true },

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -113,7 +113,8 @@ export class DataSource extends Disposable {
 		this.gitFormatLog = [
 			'%H', '%P', // Hash & Parent Information
 			useMailmap ? '%aN' : '%an', useMailmap ? '%aE' : '%ae', dateType, // Author / Commit Information
-			'%B' // Body
+			'%B', // Body
+			'%N' // Notes
 		].join(GIT_LOG_SEPARATOR);
 
 		this.gitFormatStash = [
@@ -221,7 +222,7 @@ export class DataSource extends Disposable {
 					if (refData.head === commits[i].hash) {
 						const numUncommittedChanges = await this.getUncommittedChanges(repo);
 						if (numUncommittedChanges > 0) {
-							commits.unshift({ hash: UNCOMMITTED, parents: [refData.head], author: '*', email: '', date: Math.round((new Date()).getTime() / 1000), message: 'Uncommitted Changes (' + numUncommittedChanges + ')' });
+							commits.unshift({ hash: UNCOMMITTED, parents: [refData.head], author: '*', email: '', date: Math.round((new Date()).getTime() / 1000), message: 'Uncommitted Changes (' + numUncommittedChanges + ')', notes: '' });
 						}
 						break;
 					}
@@ -259,6 +260,7 @@ export class DataSource extends Disposable {
 					email: stash.email,
 					date: stash.date,
 					message: stash.message,
+					notes: '',
 					heads: [], tags: [], remotes: [],
 					stash: {
 						selector: stash.selector,
@@ -798,6 +800,17 @@ export class DataSource extends Disposable {
 	}
 
 	/**
+	 * Add a note to a commit.
+	 * @param repo The path of the repository.
+	 * @param commitHash The hash of the commit the note should be added to.
+	 * @param notes The note contents.
+	 * @returns The ErrorInfo from the executed command.
+	 */
+	public addNote(repo: string, commitHash: string, notes: string) {
+		return this.runGitCommand(['notes', 'add', '-m', notes, commitHash], repo);
+	}
+
+	/**
 	 * Delete an existing tag from a repository.
 	 * @param repo The path of the repository.
 	 * @param tagName The name of the tag.
@@ -821,6 +834,16 @@ export class DataSource extends Disposable {
 
 		if (status !== null && status.includes('not found')) return null;
 		return status;
+	}
+
+	/**
+	 * Delete a note from a commit.
+	 * @param repo The path of the repository.
+	 * @param commitHash The hash of the commit the note should be deleted from.
+	 * @returns The ErrorInfo from the executed command.
+	 */
+	public deleteNote(repo: string, commitHash: string) {
+		return this.runGitCommand(['notes', 'remove', commitHash], repo);
 	}
 
 
@@ -1263,6 +1286,17 @@ export class DataSource extends Disposable {
 		}
 	}
 
+	/**
+	 * Edit a note on a commit.
+	 * @param repo The path of the repository.
+	 * @param commitHash The hash of the commit the note should be edited on.
+	 * @param notes The new note contents.
+	 * @returns The ErrorInfo from the executed command.
+	 */
+	public editNote(repo: string, commitHash: string, notes: string) {
+		return this.runGitCommand(['notes', 'add', '-f', '-m', notes, commitHash], repo);
+	}
+
 
 	/* Git Action Methods - Config */
 
@@ -1683,15 +1717,17 @@ export class DataSource extends Disposable {
 			const commits: GitCommitRecord[] = [];
 			for (const rec of records) {
 				const parts = rec.split(GIT_LOG_SEPARATOR);
-				// parts = [hash, parents, author, email, date, full body]
+				// parts = [hash, parents, author, email, date, full body, notes]
 				if (parts.length < 6) continue;
+				const hasNotesField = parts.length > 6;
 				commits.push({
 					hash: parts[0],
 					parents: parts[1] ? parts[1].split(' ') : [],
 					author: parts[2],
 					email: parts[3],
 					date: parseInt(parts[4], 10),
-					message: parts.slice(5).join(GIT_LOG_SEPARATOR)
+					message: hasNotesField ? parts.slice(5, parts.length - 1).join(GIT_LOG_SEPARATOR) : parts.slice(5).join(GIT_LOG_SEPARATOR),
+					notes: hasNotesField ? removeTrailingBlankLines(parts[parts.length - 1].split(EOL_REGEX)).join('\n') : ''
 				});
 			}
 			return commits;
@@ -2136,6 +2172,7 @@ interface GitCommitRecord {
 	email: string;
 	date: number;
 	message: string;
+	notes: string;
 }
 
 interface GitCommitData {

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -206,6 +206,12 @@ export class GitGraphView extends Disposable {
 					errors: errorInfos
 				});
 				break;
+			case 'addNote':
+				this.sendMessage({
+					command: 'addNote',
+					error: await this.dataSource.addNote(msg.repo, msg.commitHash, msg.notes)
+				});
+				break;
 			case 'applyStash':
 				this.sendMessage({
 					command: 'applyStash',
@@ -342,6 +348,12 @@ export class GitGraphView extends Disposable {
 				this.sendMessage({
 					command: 'deleteTag',
 					error: await this.dataSource.deleteTag(msg.repo, msg.tagName, msg.deleteOnRemote)
+				});
+				break;
+			case 'deleteNote':
+				this.sendMessage({
+					command: 'deleteNote',
+					error: await this.dataSource.deleteNote(msg.repo, msg.commitHash)
 				});
 				break;
 			case 'deleteUserDetails':
@@ -578,6 +590,12 @@ export class GitGraphView extends Disposable {
 				this.sendMessage({
 					command: 'editCommitMessage',
 					error: await this.dataSource.editCommitMessage(msg.repo, msg.commitHash, msg.message)
+				});
+				break;
+			case 'editNote':
+				this.sendMessage({
+					command: 'editNote',
+					error: await this.dataSource.editNote(msg.repo, msg.commitHash, msg.notes)
 				});
 				break;
 

--- a/src/repoFileWatcher.ts
+++ b/src/repoFileWatcher.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { Logger } from './logger';
 import { getPathFromUri } from './utils';
 
-const FILE_CHANGE_REGEX = /(^\.git\/(config|index|HEAD|refs\/stash|refs\/heads\/.*|refs\/remotes\/.*|refs\/tags\/.*)$)|(^(?!\.git).*$)|(^\.git[^\/]+$)/;
+const FILE_CHANGE_REGEX = /(^\.git\/(config|index|HEAD|refs\/stash|refs\/heads\/.*|refs\/remotes\/.*|refs\/tags\/.*|refs\/notes\/.*)$)|(^(?!\.git).*$)|(^\.git[^\/]+$)/;
 
 /**
  * Watches a Git repository for file events.

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface GitCommit {
 	readonly email: string;
 	readonly date: number;
 	readonly message: string;
+	readonly notes: string;
 	readonly heads: ReadonlyArray<string>;
 	readonly tags: ReadonlyArray<GitCommitTag>;
 	readonly remotes: ReadonlyArray<GitCommitRemote>;
@@ -371,6 +372,7 @@ export interface ContextMenuActionsVisibility {
 		readonly copyName: boolean;
 	};
 	readonly commit: {
+		readonly addNote: boolean;
 		readonly addTag: boolean;
 		readonly createBranch: boolean;
 		readonly checkout: boolean;
@@ -384,6 +386,12 @@ export interface ContextMenuActionsVisibility {
 		readonly editMessage: boolean;
 		readonly copyHash: boolean;
 		readonly copySubject: boolean;
+	};
+	readonly note: {
+		readonly view: boolean;
+		readonly edit: boolean;
+		readonly delete: boolean;
+		readonly copy: boolean;
 	};
 	readonly commitDetailsViewFile: {
 		readonly viewDiff: boolean;
@@ -631,6 +639,15 @@ export interface ResponseAddTag extends ResponseWithMultiErrorInfo {
 	readonly commitHash: string;
 }
 
+export interface RequestAddNote extends RepoRequest {
+	readonly command: 'addNote';
+	readonly commitHash: string;
+	readonly notes: string;
+}
+export interface ResponseAddNote extends ResponseWithErrorInfo {
+	readonly command: 'addNote';
+}
+
 export interface RequestApplyStash extends RepoRequest {
 	readonly command: 'applyStash';
 	readonly selector: string;
@@ -817,6 +834,14 @@ export interface RequestDeleteTag extends RepoRequest {
 }
 export interface ResponseDeleteTag extends ResponseWithErrorInfo {
 	readonly command: 'deleteTag';
+}
+
+export interface RequestDeleteNote extends RepoRequest {
+	readonly command: 'deleteNote';
+	readonly commitHash: string;
+}
+export interface ResponseDeleteNote extends ResponseWithErrorInfo {
+	readonly command: 'deleteNote';
 }
 
 export interface RequestDeleteUserDetails extends RepoRequest {
@@ -1181,6 +1206,15 @@ export interface ResponseEditCommitMessage extends ResponseWithErrorInfo {
 	readonly command: 'editCommitMessage';
 }
 
+export interface RequestEditNote extends RepoRequest {
+	readonly command: 'editNote';
+	readonly commitHash: string;
+	readonly notes: string;
+}
+export interface ResponseEditNote extends ResponseWithErrorInfo {
+	readonly command: 'editNote';
+}
+
 export interface RequestSetGlobalViewState extends BaseMessage {
 	readonly command: 'setGlobalViewState';
 	readonly state: GitGraphViewGlobalState;
@@ -1284,6 +1318,7 @@ export interface ResponseViewScm extends ResponseWithErrorInfo {
 
 export type RequestMessage =
 	RequestAddRemote
+	| RequestAddNote
 	| RequestAddTag
 	| RequestApplyStash
 	| RequestBranchFromStash
@@ -1301,12 +1336,14 @@ export type RequestMessage =
 	| RequestDeleteBranch
 	| RequestDeleteRemote
 	| RequestDeleteRemoteBranch
+	| RequestDeleteNote
 	| RequestDeleteTag
 	| RequestDeleteUserDetails
 	| RequestDropCommit
 	| RequestDropStash
 	| RequestUndoLastCommit
 	| RequestEditCommitMessage
+	| RequestEditNote
 	| RequestEditRemote
 	| RequestEditUserDetails
 	| RequestEndCodeReview
@@ -1350,6 +1387,7 @@ export type RequestMessage =
 
 export type ResponseMessage =
 	ResponseAddRemote
+	| ResponseAddNote
 	| ResponseAddTag
 	| ResponseApplyStash
 	| ResponseBranchFromStash
@@ -1367,12 +1405,14 @@ export type ResponseMessage =
 	| ResponseDeleteBranch
 	| ResponseDeleteRemote
 	| ResponseDeleteRemoteBranch
+	| ResponseDeleteNote
 	| ResponseDeleteTag
 	| ResponseDeleteUserDetails
 	| ResponseDropCommit
 	| ResponseDropStash
 	| ResponseUndoLastCommit
 	| ResponseEditCommitMessage
+	| ResponseEditNote
 	| ResponseEditRemote
 	| ResponseEditUserDetails
 	| ResponseExportRepoConfig

--- a/tests/dataSource.test.ts
+++ b/tests/dataSource.test.ts
@@ -4782,6 +4782,59 @@ describe('DataSource', () => {
 		});
 	});
 
+	describe('addNote', () => {
+		it('Should add a note to a commit', async () => {
+			// Setup
+			mockGitSuccessOnce();
+
+			// Run
+			const result = await dataSource.addNote('/path/to/repo', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b', 'note');
+
+			// Assert
+			expect(result).toBe(null);
+			expect(spyOnSpawn).toBeCalledWith('/path/to/git', ['notes', 'add', '-m', 'note', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b'], expect.objectContaining({ cwd: '/path/to/repo' }));
+		});
+
+		it('Should return an error message thrown by git', async () => {
+			// Setup
+			mockGitThrowingErrorOnce();
+
+			// Run
+			const result = await dataSource.addNote('/path/to/repo', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b', 'note');
+
+			// Assert
+			expect(result).toBe('error message');
+		});
+	});
+
+	describe('editNote', () => {
+		it('Should edit a note on a commit', async () => {
+			// Setup
+			mockGitSuccessOnce();
+
+			// Run
+			const result = await dataSource.editNote('/path/to/repo', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b', 'updated note');
+
+			// Assert
+			expect(result).toBe(null);
+			expect(spyOnSpawn).toBeCalledWith('/path/to/git', ['notes', 'add', '-f', '-m', 'updated note', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b'], expect.objectContaining({ cwd: '/path/to/repo' }));
+		});
+	});
+
+	describe('deleteNote', () => {
+		it('Should delete a note from a commit', async () => {
+			// Setup
+			mockGitSuccessOnce();
+
+			// Run
+			const result = await dataSource.deleteNote('/path/to/repo', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b');
+
+			// Assert
+			expect(result).toBe(null);
+			expect(spyOnSpawn).toBeCalledWith('/path/to/git', ['notes', 'remove', '1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b'], expect.objectContaining({ cwd: '/path/to/repo' }));
+		});
+	});
+
 	describe('fetch', () => {
 		it('Should fetch all remotes', async () => {
 			// Setup

--- a/web/dialog.ts
+++ b/web/dialog.ts
@@ -223,7 +223,7 @@ class Dialog {
 				} else if (input.type === DialogInputType.Checkbox) {
 					inputHtml = '<td class="inputCol"' + (infoColRequired ? ' colspan="2"' : '') + '><span class="dialogFormCheckbox"><label><input id="dialogInput' + id + '" type="checkbox"' + (input.value ? ' checked' : '') + ' tabindex="' + (id + 1) + '"/><span class="customCheckbox"></span>' + (multiElement && !multiCheckbox ? '' : input.name) + '</label>' + infoHtml + '</span></td>';
 				} else if (input.type === DialogInputType.Textarea) {
-					inputHtml = '<td class="inputCol"><textarea id="dialogInput' + id + '"' + (input.placeholder !== null ? ' placeholder="' + escapeHtml(input.placeholder) + '"' : '') + ' tabindex="' + (id + 1) + '" rows="' + (input.lines || 4) + '" style="resize:vertical;width:100%;font-family:inherit;padding:4px;box-sizing:border-box;margin-top:2px;">' + escapeHtml(input.default) + '</textarea></td>' + (infoColRequired ? '<td>' + infoHtml + '</td>' : '');
+					inputHtml = '<td class="inputCol"><textarea id="dialogInput' + id + '"' + (input.placeholder !== null ? ' placeholder="' + escapeHtml(input.placeholder) + '"' : '') + ' tabindex="' + (id + 1) + '" rows="' + (input.lines || 4) + '">' + escapeHtml(input.default) + '</textarea></td>' + (infoColRequired ? '<td>' + infoHtml + '</td>' : '');
 				} else {
 					inputHtml = '<td class="inputCol"><input id="dialogInput' + id + '" type="text" value="' + escapeHtml(input.default) + '"' + (input.type === DialogInputType.Text && input.placeholder !== null ? ' placeholder="' + escapeHtml(input.placeholder) + '"' : '') + ' tabindex="' + (id + 1) + '"/></td>' + (infoColRequired ? '<td>' + infoHtml + '</td>' : '');
 				}
@@ -297,9 +297,9 @@ class Dialog {
 			});
 		}
 
-		if (inputs.length > 0 && (inputs[0].type === DialogInputType.Text || inputs[0].type === DialogInputType.TextRef)) {
+		if (inputs.length > 0 && (inputs[0].type === DialogInputType.Text || inputs[0].type === DialogInputType.Textarea || inputs[0].type === DialogInputType.TextRef)) {
 			// If the first input is a text field, set focus to it.
-			(<HTMLInputElement>document.getElementById('dialogInput0')).focus();
+			(<HTMLInputElement | HTMLTextAreaElement>document.getElementById('dialogInput0')).focus();
 		}
 	}
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -380,6 +380,7 @@ class GitGraphView {
 
 		if (!this.currentRepoLoading && !this.currentRepoRefreshState.hard && this.moreCommitsAvailable === moreAvailable && this.onlyFollowFirstParent === onlyFollowFirstParent && this.commitHead === commitHead && commits.length > 0 && arraysEqual(this.commits, commits, (a, b) =>
 			a.hash === b.hash &&
+			a.notes === b.notes &&
 			arraysStrictlyEqual(a.heads, b.heads) &&
 			arraysEqual(a.tags, b.tags, (a: GG.GitCommitTag, b: GG.GitCommitTag) => a.name === b.name && a.annotated === b.annotated) &&
 			arraysEqual(a.remotes, b.remotes, (a: GG.GitCommitRemote, b: GG.GitCommitRemote) => a.name === b.name && a.remote === b.remote) &&
@@ -960,7 +961,7 @@ class GitGraphView {
 			message += '</span>';
 			let date = formatShortDate(commit.date);
 			let branchLabels = getBranchLabels(commit.heads, commit.remotes);
-			let refBranches = '', refTags = '', j, k, refName, remoteName, refActive, refHtml, branchCheckedOutAtCommit: string | null = null;
+			let refBranches = '', refTags = '', refNotes = '', j, k, refName, remoteName, refActive, refHtml, branchCheckedOutAtCommit: string | null = null;
 
 			for (j = 0; j < branchLabels.heads.length; j++) {
 				refName = escapeHtml(branchLabels.heads[j].name);
@@ -1004,6 +1005,12 @@ class GitGraphView {
 				refBranches = '<span class="gitRef stash" data-name="' + refName + '">' + SVG_ICONS.stash + '<span class="gitRefName" data-fullref="' + refName + '">' + escapeHtml(commit.stash.selector.substring(5)) + '</span></span>' + refBranches;
 			}
 
+			if (commit.notes !== '') {
+				let notePreview = commit.notes.split(/\r?\n/)[0].trim();
+				if (notePreview.length > 40) notePreview = notePreview.substring(0, 40) + ELLIPSIS;
+				refNotes = '<span class="gitRef note" data-name="' + escapeHtml(commit.hash) + '" title="' + escapeHtml(commit.notes) + '">' + SVG_ICONS.info + '<span class="gitRefName" data-fullref="' + escapeHtml(commit.hash) + '">Note' + (notePreview !== '' ? ': ' + escapeHtml(notePreview) : '') + '</span></span>';
+			}
+
 			const commitDot = commit.hash === this.commitHead
 				? '<span class="commitHeadDot" title="' + (branchCheckedOutAtCommit !== null
 					? 'The branch ' + escapeHtml('"' + branchCheckedOutAtCommit + '"') + ' is currently checked out at this commit'
@@ -1012,7 +1019,7 @@ class GitGraphView {
 				: '';
 
 			html += '<tr class="commit' + (commit.hash === currentHash ? ' current' : '') + (mutedCommits[i] ? ' mute' : '') + '"' + (commit.hash !== UNCOMMITTED ? '' : ' id="uncommittedChanges"') + ' data-id="' + i + '" data-color="' + vertexColours[i] + '">' +
-				(this.config.referenceLabels.branchLabelsAlignedToGraph ? '<td>' + getResizeColHtml(0) + (refBranches !== '' ? '<span style="margin-left:' + (widthsAtVertices[i] - 4) + 'px"' + refBranches.substring(5) : '') + '</td><td>' + getResizeColHtml(1) + '<span class="description">' + commitDot : '<td>' + getResizeColHtml(0) + '</td><td>' + getResizeColHtml(1) + '<span class="description">' + commitDot + refBranches) + (this.config.referenceLabels.tagLabelsOnRight ? message + (refTags !== '' ? '<span class="tagsWrapper">' + refTags + '</span>' : '') : refTags + message) + '</span></td>' +
+				(this.config.referenceLabels.branchLabelsAlignedToGraph ? '<td>' + getResizeColHtml(0) + (refBranches !== '' ? '<span style="margin-left:' + (widthsAtVertices[i] - 4) + 'px"' + refBranches.substring(5) : '') + '</td><td>' + getResizeColHtml(1) + '<span class="description">' + commitDot : '<td>' + getResizeColHtml(0) + '</td><td>' + getResizeColHtml(1) + '<span class="description">' + commitDot + refBranches) + (this.config.referenceLabels.tagLabelsOnRight ? refNotes + message + (refTags !== '' ? '<span class="tagsWrapper">' + refTags + '</span>' : '') : refTags + refNotes + message) + '</span></td>' +
 				(colVisibility.date ? '<td class="dateCol text" title="' + date.title + '">' + getResizeColHtml(2) + date.formatted + '</td>' : '') +
 				(colVisibility.author ? '<td class="authorCol text" title="' + escapeHtml(commit.author + ' <' + commit.email + '>') + '">' + getResizeColHtml(3) + (this.config.fetchAvatars ? '<span class="avatar" data-email="' + escapeHtml(commit.email) + '">' + (typeof this.avatars[commit.email] === 'string' ? '<img class="avatarImg" src="' + this.avatars[commit.email] + '">' : '') + '</span>' : '') + escapeHtml(commit.author) + '</td>' : '') +
 				(colVisibility.commit ? '<td class="text" title="' + escapeHtml(commit.hash) + '">' + getResizeColHtml(4) + abbrevCommit(commit.hash) + '</td>' : '') +
@@ -1300,6 +1307,10 @@ class GitGraphView {
 		const commit = this.commits[this.commitLookup[hash]];
 		return [[
 			{
+				title: 'Add Note' + ELLIPSIS,
+				visible: visibility.addNote && commit.notes === '',
+				onClick: () => this.addNoteAction(hash, '', target)
+			}, {
 				title: 'Add Tag' + ELLIPSIS,
 				visible: visibility.addTag,
 				onClick: () => this.addTagAction(hash, '', this.config.dialogDefaults.addTag.type, '', null, target)
@@ -1443,6 +1454,38 @@ class GitGraphView {
 				visible: visibility.copySubject,
 				onClick: () => {
 					sendMessage({ command: 'copyToClipboard', type: 'Commit Subject', data: commit.message });
+				}
+			}
+		]];
+	}
+
+	private getNoteContextMenuActions(target: DialogTarget & RefTarget): ContextMenuActions {
+		const hash = target.hash, visibility = this.config.contextMenuActionsVisibility.note;
+		const commit = this.commits[this.commitLookup[hash]];
+		return [[
+			{
+				title: 'View Note',
+				visible: visibility.view,
+				onClick: () => this.viewNoteAction(hash, commit.notes)
+			}, {
+				title: 'Edit Note' + ELLIPSIS,
+				visible: visibility.edit,
+				onClick: () => this.editNoteAction(hash, commit.notes, target)
+			}, {
+				title: 'Delete Note' + ELLIPSIS,
+				visible: visibility.delete,
+				onClick: () => {
+					dialog.showConfirmation('Are you sure you want to delete the note on commit <b><i>' + abbrevCommit(hash) + '</i></b>?', 'Yes, delete', () => {
+						runAction({ command: 'deleteNote', repo: this.currentRepo, commitHash: hash }, 'Deleting Note');
+					}, target);
+				}
+			}
+		], [
+			{
+				title: 'Copy Note to Clipboard',
+				visible: visibility.copy,
+				onClick: () => {
+					sendMessage({ command: 'copyToClipboard', type: 'Note', data: commit.notes });
 				}
 			}
 		]];
@@ -1769,6 +1812,23 @@ class GitGraphView {
 
 	/* Actions */
 
+	private addNoteAction(hash: string, initialNotes: string, target: DialogTarget & CommitTarget) {
+		dialog.showForm('Add note to commit <b><i>' + abbrevCommit(hash) + '</i></b>:', [{
+			type: DialogInputType.Textarea,
+			lines: 5,
+			name: 'Note',
+			default: initialNotes,
+			placeholder: 'Enter the note'
+		}], 'Add Note', (values) => {
+			const notes = <string>values[0];
+			if (notes.trim() === '') {
+				dialog.showError('Note cannot be empty.', null, null, null);
+				return;
+			}
+			runAction({ command: 'addNote', repo: this.currentRepo, commitHash: hash, notes: notes }, 'Adding Note');
+		}, target);
+	}
+
 	private addTagAction(hash: string, initialName: string, initialType: GG.TagType, initialMessage: string, initialPushToRemote: string | null, target: DialogTarget & CommitTarget, isInitialLoad: boolean = true) {
 		let mostRecentTagsIndex = -1;
 		for (let i = 0; i < this.commits.length; i++) {
@@ -1841,6 +1901,28 @@ class GitGraphView {
 				runAddTagAction(false);
 			}
 		}, target);
+	}
+
+	private editNoteAction(hash: string, initialNotes: string, target: DialogTarget & RefTarget) {
+		dialog.showForm('Edit note on commit <b><i>' + abbrevCommit(hash) + '</i></b>:', [{
+			type: DialogInputType.Textarea,
+			lines: 5,
+			name: 'Note',
+			default: initialNotes,
+			placeholder: 'Enter the note'
+		}], 'Update Note', (values) => {
+			const notes = <string>values[0];
+			if (notes.trim() === '') {
+				dialog.showError('Note cannot be empty.', null, null, null);
+				return;
+			}
+			if (notes === initialNotes) return;
+			runAction({ command: 'editNote', repo: this.currentRepo, commitHash: hash, notes: notes }, 'Editing Note');
+		}, target);
+	}
+
+	private viewNoteAction(hash: string, notes: string) {
+		dialog.showMessage('Note on commit <b><i>' + abbrevCommit(hash) + '</i></b>:' + '<pre>' + escapeHtml(notes) + '</pre>');
 	}
 
 	private checkoutBranchAction(refName: string, remote: string | null, prefillName: string | null, target: DialogTarget & (CommitTarget | RefTarget)) {
@@ -2537,7 +2619,9 @@ class GitGraphView {
 				};
 
 				let actions: ContextMenuActions;
-				if (eventElem.classList.contains(CLASS_REF_STASH)) {
+				if (eventElem.classList.contains(CLASS_REF_NOTE)) {
+					actions = this.getNoteContextMenuActions(target);
+				} else if (eventElem.classList.contains(CLASS_REF_STASH)) {
 					actions = this.getStashContextMenuActions(target);
 				} else if (eventElem.classList.contains(CLASS_REF_TAG)) {
 					actions = this.getTagContextMenuActions(eventElem.dataset.tagtype === 'annotated', target);
@@ -3515,6 +3599,9 @@ window.addEventListener('load', () => {
 					refreshAndDisplayErrors(msg.errors, 'Unable to Add Tag');
 				}
 				break;
+			case 'addNote':
+				refreshOrDisplayError(msg.error, 'Unable to Add Note');
+				break;
 			case 'applyStash':
 				refreshOrDisplayError(msg.error, 'Unable to Apply Stash');
 				break;
@@ -3579,6 +3666,9 @@ window.addEventListener('load', () => {
 				break;
 			case 'deleteTag':
 				refreshOrDisplayError(msg.error, 'Unable to Delete Tag');
+				break;
+			case 'deleteNote':
+				refreshOrDisplayError(msg.error, 'Unable to Delete Note');
 				break;
 			case 'deleteUserDetails':
 				finishOrDisplayErrors(msg.errors, 'Unable to Remove Git User Details', () => gitGraph.requestLoadConfig(), true);
@@ -3693,6 +3783,9 @@ window.addEventListener('load', () => {
 				break;
 			case 'editCommitMessage':
 				refreshOrDisplayError(msg.error, 'Unable to Edit Commit Message');
+				break;
+			case 'editNote':
+				refreshOrDisplayError(msg.error, 'Unable to Edit Note');
 				break;
 
 			case 'setGlobalViewState':

--- a/web/styles/dialog.css
+++ b/web/styles/dialog.css
@@ -83,7 +83,7 @@ body.vscode-high-contrast .dialog{
 	background-color:var(--vscode-menu-foreground);
 }
 
-.dialogContent > table.dialogForm input[type=text]{
+.dialogContent > table.dialogForm input[type=text], .dialogContent > table.dialogForm textarea{
 	width:100%;
 	padding:4px 6px;
 	box-sizing:border-box;
@@ -96,10 +96,15 @@ body.vscode-high-contrast .dialog{
 	font-size:13px;
 	line-height:17px;
 }
-.dialogContent > table.dialogForm input[type=text]:focus, .dialogContent .dialogFormCheckbox > label > input[type=checkbox]:focus ~ .customCheckbox, .dialogContent .dialogFormRadio > label > input[type=radio]:focus ~ .customRadio{
+.dialogContent > table.dialogForm textarea{
+	min-height:72px;
+	resize:vertical;
+	margin-top:2px;
+}
+.dialogContent > table.dialogForm input[type=text]:focus, .dialogContent > table.dialogForm textarea:focus, .dialogContent .dialogFormCheckbox > label > input[type=checkbox]:focus ~ .customCheckbox, .dialogContent .dialogFormRadio > label > input[type=radio]:focus ~ .customRadio{
 	border-color:var(--vscode-focusBorder);
 }
-.dialogContent > table.dialogForm input[type=text]::placeholder{
+.dialogContent > table.dialogForm input[type=text]::placeholder, .dialogContent > table.dialogForm textarea::placeholder{
 	color:var(--vscode-menu-foreground);
 	opacity:0.4;
 }

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -758,9 +758,15 @@ body.vscode-high-contrast #commitTable tr.commit.findCurrentCommit{
 body.branchLabelsAlignedToGraph tr.commit td:first-child .gitRef:last-child{
 	margin-right:0;
 }
-body.tagLabelsRightAligned .gitRef.tag{
+body.tagLabelsRightAligned .gitRef.tag, body.tagLabelsRightAligned .gitRef.note{
 	margin-left:5px;
 	margin-right:0;
+}
+
+.dialog pre{
+	margin:8px 0 0 0;
+	white-space:pre-wrap;
+	font-family:var(--vscode-editor-font-family);
 }
 
 

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -89,6 +89,7 @@ const CLASS_PENDING_REVIEW = 'pendingReview';
 const CLASS_REFRESHING = 'refreshing';
 const CLASS_REF_HEAD = 'head';
 const CLASS_REF_REMOTE = 'remote';
+const CLASS_REF_NOTE = 'note';
 const CLASS_REF_STASH = 'stash';
 const CLASS_REF_TAG = 'tag';
 const CLASS_SELECTED = 'selected';


### PR DESCRIPTION
Add support for git notes

This adds support for git notes in the graph view, based on the idea from the original issue: https://github.com/mhutchie/vscode-git-graph/issues/475

Commits with notes now show a small note label in the table, similar to how branches and tags are shown. There is also a new “Add Note” action in the commit menu, and existing notes can be viewed, edited, deleted, or copied from their context menu.

The table is refreshed after note changes, and changes made outside the extension are picked up from `.git/refs/notes/*` too.

I also added a few tests for the git note commands.

Note, I did this mostly with the help of Codex. I don't know if you have a policy against that. It is useful for me at least. I needed it and I got it done in 15 mins. Weird times...